### PR TITLE
Stop Blazor WebView messages after window close

### DIFF
--- a/Photino.Blazor/PhotinoWebViewManager.cs
+++ b/Photino.Blazor/PhotinoWebViewManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -18,6 +17,7 @@ internal sealed class PhotinoWebViewManager : WebViewManager
     private readonly Task _outgoingMessagesTask;
     private readonly Task _incomingMessagesTask;
     private readonly CancellationTokenSource _cts = new();
+    private int _messagePumpsStopped;
 
     private static readonly TimeSpan s_rendererDisposeTimeout = TimeSpan.FromSeconds(5);
 
@@ -53,10 +53,13 @@ internal sealed class PhotinoWebViewManager : WebViewManager
         });
 
         _window.WebMessageReceived += WebMessageReceived;
+        _window.Closed += WindowClosed;
 
         _outgoingMessagesTask = Task.Run(() => ProcessOutgoingMessagesAsync(_cts.Token), _cts.Token);
         _incomingMessagesTask = Task.Run(() => ProcessIncomingMessagesAsync(_cts.Token), _cts.Token);
     }
+
+    private bool AreMessagePumpsStopped => Volatile.Read(ref _messagePumpsStopped) != 0;
 
     internal Stream? HandleWebRequestCore(string url, out string? contentType)
     {
@@ -95,14 +98,25 @@ internal sealed class PhotinoWebViewManager : WebViewManager
 
     protected override void SendMessage(string message)
     {
-        if (!_outgoingMessages.Writer.TryWrite(message))
+        if (AreMessagePumpsStopped)
+            return;
+
+        if (!_outgoingMessages.Writer.TryWrite(message) && !AreMessagePumpsStopped)
             Log("Failed to enqueue outgoing WebView message because the message pump is closed.");
     }
 
     private void WebMessageReceived(object? sender, string message)
     {
-        if (!_incomingMessages.Writer.TryWrite(message))
+        if (AreMessagePumpsStopped)
+            return;
+
+        if (!_incomingMessages.Writer.TryWrite(message) && !AreMessagePumpsStopped)
             Log("Failed to enqueue incoming WebView message because the message pump is closed.");
+    }
+
+    private void WindowClosed(object? sender, EventArgs e)
+    {
+        StopAcceptingMessages();
     }
 
     private async Task ProcessOutgoingMessagesAsync(CancellationToken cancellationToken)
@@ -115,9 +129,20 @@ internal sealed class PhotinoWebViewManager : WebViewManager
             {
                 while (reader.TryRead(out var message))
                 {
+                    if (AreMessagePumpsStopped)
+                        return;
+
                     try
                     {
-                        _window.SendWebMessage(message);
+                        await _window.SendWebMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+                    catch (InvalidOperationException) when (AreMessagePumpsStopped || _window.IsClosed)
+                    {
+                        return;
                     }
                     catch (Exception ex)
                     {
@@ -141,6 +166,9 @@ internal sealed class PhotinoWebViewManager : WebViewManager
             {
                 while (reader.TryRead(out var message))
                 {
+                    if (AreMessagePumpsStopped)
+                        return;
+
                     try
                     {
                         // TODO: Photino should provide the source URL for the message so this can be validated.
@@ -159,13 +187,36 @@ internal sealed class PhotinoWebViewManager : WebViewManager
         }
     }
 
-    protected override async ValueTask DisposeAsyncCore()
+    private void StopAcceptingMessages()
     {
-        ExceptionDispatchInfo? disposeException = null;
+        if (Interlocked.Exchange(ref _messagePumpsStopped, 1) != 0)
+            return;
+
+        _window.WebMessageReceived -= WebMessageReceived;
+        _window.Closed -= WindowClosed;
+
+        // Stop accepting new messages and wake the message pumps.
+        _outgoingMessages.Writer.TryComplete();
+        _incomingMessages.Writer.TryComplete();
 
         try
         {
-            await DisposeBaseAsyncWithTimeout().ConfigureAwait(false);
+            _cts.Cancel();
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        ExceptionDispatchInfo? disposeException = null;
+        var suppressDisposeTimeoutLog = AreMessagePumpsStopped;
+
+        try
+        {
+            await DisposeBaseAsyncWithTimeout(suppressDisposeTimeoutLog).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -174,20 +225,7 @@ internal sealed class PhotinoWebViewManager : WebViewManager
 
         try
         {
-            _window.WebMessageReceived -= WebMessageReceived;
-
-            // Stop accepting new messages and wake the message pumps.
-            _outgoingMessages.Writer.TryComplete();
-            _incomingMessages.Writer.TryComplete();
-
-            try
-            {
-                await _cts.CancelAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                // ignored
-            }
+            StopAcceptingMessages();
 
             try
             {
@@ -209,7 +247,7 @@ internal sealed class PhotinoWebViewManager : WebViewManager
         disposeException?.Throw();
     }
 
-    private async Task DisposeBaseAsyncWithTimeout()
+    private async Task DisposeBaseAsyncWithTimeout(bool suppressTimeoutLog)
     {
         var disposeTask = base.DisposeAsyncCore().AsTask();
 
@@ -223,10 +261,15 @@ internal sealed class PhotinoWebViewManager : WebViewManager
             return;
         }
 
-        Log($"Timed out while disposing Blazor renderer after {s_rendererDisposeTimeout}.");
+        if (!suppressTimeoutLog)
+            Log($"Timed out while disposing Blazor renderer after {s_rendererDisposeTimeout}.");
 
         _ = disposeTask.ContinueWith(
-            task => Log($"Blazor renderer disposal failed after timeout: {task.Exception}"),
+            task =>
+            {
+                if (!suppressTimeoutLog)
+                    Log($"Blazor renderer disposal failed after timeout: {task.Exception}");
+            },
             CancellationToken.None,
             TaskContinuationOptions.OnlyOnFaulted,
             TaskScheduler.Default);

--- a/Photino.Blazor/PhotinoX.Blazor.csproj
+++ b/Photino.Blazor/PhotinoX.Blazor.csproj
@@ -27,7 +27,7 @@ Maintained fork of Photino.Blazor.</Description>
 	</ItemGroup>
 
   <ItemGroup Condition="'$(PhotinoX_UseLocalProjects)' != 'true'">
-    <PackageReference Include="PhotinoX" Version="5.0.0-preview.2" />
+    <PackageReference Include="PhotinoX" Version="5.0.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PhotinoX_UseLocalProjects)' == 'true'">

--- a/Samples/Photino.Blazor.EmbeddedMudBlazorSample/Photino.Blazor.EmbeddedMudBlazorSample/Photino.Blazor.EmbeddedMudBlazorSample.csproj
+++ b/Samples/Photino.Blazor.EmbeddedMudBlazorSample/Photino.Blazor.EmbeddedMudBlazorSample/Photino.Blazor.EmbeddedMudBlazorSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ApplicationIcon>wwwroot/favicon.ico</ApplicationIcon>

--- a/Samples/Photino.Blazor.Sample/Photino.Blazor.Sample.csproj
+++ b/Samples/Photino.Blazor.Sample/Photino.Blazor.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	
 	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
+		<OutputType>Exe</OutputType>
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 	</PropertyGroup>


### PR DESCRIPTION
## Summary

Stops the PhotinoX.Blazor WebView message pumps when the native Photino window is closed.

During shutdown, Blazor component disposal can still enqueue JS interop cleanup messages. If the native window has already been closed, those messages should not be sent to the WebView anymore.

This prevents `SendWebMessage` from being called after the Photino window has been closed.

## Changes

- Stop accepting incoming and outgoing WebView messages when the native window closes.
- Complete the message channels and cancel the message pump tasks during shutdown.
- Drop queued messages after the message pumps have been stopped.
- Suppress expected renderer disposal timeout logging when disposal happens after the native window has already closed.
- SendWebMessageAsync now accepts a cancellation token so Blazor message pumps can cancel pending sends during shutdown.

Related to ivanvoyager/PhotinoX#16